### PR TITLE
fix: 修复验证码登录

### DIFF
--- a/module/login_cellphone.js
+++ b/module/login_cellphone.js
@@ -18,7 +18,7 @@ module.exports = async (query, request) => {
   let result = await request(
     `/api/w/login/cellphone`,
     data,
-    createOption(query),
+    createOption(query, "weapi"),
   )
 
   if (result.body.code === 200) {


### PR DESCRIPTION
通过将加密方式从默认的 eapi 改成 weapi，验证码登录神奇地可以工作了

我也不知道为什么，但是确实能用