### PR TITLE
fix(server): Correctly inject client IP into request parameters

### DIFF
--- a/server.js
+++ b/server.js
@@ -238,7 +238,7 @@ async function consturctServer(moduleDefs) {
           }
           // logger.info('Requested from ip:', ip)
           obj[2] = {
-            ...obj[2],
+            ...(obj[2] || {}),
             ip,
           }
           return request(...obj)


### PR DESCRIPTION
原版的 `server.js` 逻辑是支持通过获取请求方传递的 `X-FORWARDED-FOR` Header 拿到里面的 IP 作为真实 IP 进行调用的，但由于仓库更改了 Request Options 而未更改此处逻辑，造成此处传参失败。

经我测试，在修正后的版本能正确传递这个参数，识别 RealIP 而无需在 param 里传递 `?realIP` 参数