### PR TITLE
feat: 新增灰色歌曲其他版本推荐接口

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -1167,7 +1167,10 @@ export function song_url_v1(
 ): Promise<Response>
 
 export function song_copyright_rcmd(
-  params: { songid: string | number; id?: string | number } & RequestBaseConfig,
+  params: {
+    songid?: string | number
+    id?: string | number
+  } & RequestBaseConfig,
 ): Promise<Response>
 
 export function top_album(

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -1166,6 +1166,10 @@ export function song_url_v1(
   params: { id: string | number; level: SoundQualityType } & RequestBaseConfig,
 ): Promise<Response>
 
+export function song_copyright_rcmd(
+  params: { songid: string | number; id?: string | number } & RequestBaseConfig,
+): Promise<Response>
+
 export function top_album(
   params: {
     area?: AlbumListArea

--- a/module/song_copyright_rcmd.js
+++ b/module/song_copyright_rcmd.js
@@ -1,0 +1,9 @@
+// 灰色歌曲的其他版本推荐
+
+const createOption = require('../util/option.js')
+module.exports = (query, request) => {
+  const data = {
+    songid: query.songid || query.id,
+  }
+  return request(`/api/song/copyright/rcmd`, data, createOption(query, 'eapi'))
+}

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -5318,6 +5318,18 @@ let data = encodeURIComponent(
 
 **调用例子 :** `/song/creators?id=33894312`
 
+### 灰色歌曲的其他版本推荐
+
+说明 : 调用此接口, 传入灰色歌曲 id, 获取该歌曲的其他可播放版本推荐
+
+**必选参数 :**
+
+`songid`: 歌曲 id, 可使用 `id` 代替
+
+**接口地址 :** `/song/copyright/rcmd`
+
+**调用例子 :** `/song/copyright/rcmd?songid=27946878`
+
 ## 离线访问此文档
 
 此文档同时也是 Progressive Web Apps(PWA), 加入了 serviceWorker, 可离线访问


### PR DESCRIPTION
接口：/song/copyright/rcmd

官方客户端里点击灰色歌曲，会弹出来的“暂无音源，为您找到其他版本歌曲”

这个接口返回这个其他版本歌曲
