### PR TITLE
feat: add relay_play_state_submit API for song play state tracking

### DIFF
--- a/module/relay_play_state_submit.js
+++ b/module/relay_play_state_submit.js
@@ -1,0 +1,32 @@
+// 提交歌曲播放状态
+
+const createOption = require('../util/option.js')
+module.exports = (query, request) => {
+  const { id, sessionId, progress = 0, playMode = 'list_loop', type = 'song' } = query
+
+  if (!id || !sessionId) {
+    return Promise.reject({
+      status: 400,
+      body: {
+        code: 400,
+        msg: '缺少必要参数：id, sessionId',
+      },
+    })
+  }
+
+  const playStateSubmitReq = JSON.stringify({
+    resource: {
+      id: String(id),
+      type: type
+    },
+    progress: progress,
+    sessionId: sessionId,
+    playMode: playMode
+  })
+
+  const data = {
+    playStateSubmitReq: playStateSubmitReq
+  }
+
+  return request('/api/relay/play/state/submit', data, createOption(query, 'weapi'))
+}

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -2487,7 +2487,7 @@ privilege:权限相关信息
 
 **必选参数 :** `id`: 歌曲 id, `sourceid`: 歌单或专辑 id
 
-**可选参数 :** `time`: 歌曲播放时间,单位为秒
+**可选参数 :** `time`: 歌曲播放时间，单位为秒
 
 **接口地址 :** `/scrobble`
 
@@ -5337,7 +5337,29 @@ let data = encodeURIComponent(
 
 ### 指定维度音乐排行榜列表
 
-说明 : 调用此接口,可获取城市榜、城市风格榜等指定维度音乐排行榜歌曲列表
+说明 : 调用此接口，可获取城市榜、城市风格榜等指定维度音乐排行榜歌曲列表
+
+### 提交歌曲播放状态
+
+说明 : 调用此接口 , 提交歌曲播放状态信息，支持会话追踪和播放模式记录
+
+**必选参数 :**
+
+`id`: 歌曲 id
+
+`sessionId`: 播放会话 ID（每次播放生成的唯一标识，建议使用大写字母和数字组成的 12 位字符串）
+
+**可选参数 :**
+
+`progress`: 播放进度，单位为秒，默认 0
+
+`playMode`: 播放模式，可选值：`list_loop`（列表循环）、`single_loop`（单曲循环）、`random`（随机播放）、`single`（单曲播放），默认 `list_loop`
+
+`type`: 资源类型，默认 `song`
+
+**接口地址 :** `/api/relay/play/state/submit`
+
+**调用例子 :** `/api/relay/play/state/submit?id=410801653&sessionId=6H8FAKRXFX6H&progress=0&playMode=list_loop`
 
 ## 离线访问此文档
 


### PR DESCRIPTION
## 功能说明

新增歌曲播放状态提交接口，支持会话追踪和播放模式记录。

## 新增接口

- `/api/relay/play/state/submit` - 提交歌曲播放状态

## 参数说明

- `id`: 歌曲 ID（必填）
- `sessionId`: 播放会话 ID（必填）
- `progress`: 播放进度（可选，默认 0）
- `playMode`: 播放模式（可选，默认 list_loop）
- `type`: 资源类型（可选，默认 song）

## 使用示例

```
/api/relay/play/state/submit?id=410801653&sessionId=6H8FAKRXFX6H&progress=0&playMode=list_loop
```

## 与 scrobble 接口的区别

- `scrobble`: 用于上传完整的听歌记录，包含播放时长
- `relay_play_state_submit`: 用于实时播放状态同步，支持会话追踪和播放模式

## 组合使用示例

```javascript
// 开始播放
await relay_play_state_submit({
  id: songId,
  sessionId: generateSessionId(),
  progress: 0,
  playMode: 'list_loop'
})

// 结束播放
await scrobble({
  id: songId,
  sourceid: playlistId,
  time: playTime
})
```

## 文档更新

- 更新 `public/docs/home.md` 添加接口文档