### PR TITLE
feat: 新增 listen_data_song_play_rank 歌曲播放排行接口

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -2049,6 +2049,13 @@ export function listen_data_report(
   } & RequestBaseConfig,
 ): Promise<Response>
 
+export function listen_data_song_play_rank(
+  params: {
+    type?: string
+    endTime?: string | number
+  } & RequestBaseConfig,
+): Promise<Response>
+
 export function listen_data_today_song(
   params: RequestBaseConfig,
 ): Promise<Response>

--- a/module/listen_data_song_play_rank.js
+++ b/module/listen_data_song_play_rank.js
@@ -1,0 +1,12 @@
+// 听歌足迹 - 歌曲播放排行 (Top20)
+const createOption = require('../util/option.js')
+module.exports = (query, request) => {
+  return request(
+    `/api/content/activity/listen/data/song/play/rank`,
+    {
+      type: query.type || 'month', //周 week 月 month
+      endTime: query.endTime, // 不填就是本周/月的
+    },
+    createOption(query),
+  )
+}

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -4810,6 +4810,23 @@ bitrate = Math.floor(br / 1000)
 
 **接口地址 :** `/listen/data/today/song`
 
+### 听歌足迹 - 歌曲播放排行
+
+说明 : 登录后调用此接口, 获取歌曲播放排行, 返回每首歌的播放次数 (playCount); 默认返回前 20 名 (Top20), 不足则返回全部
+
+**必选参数 :**
+
+`type`: 维度类型 周 week 月 month
+
+**可选参数 :**
+
+`endTime` : 周: 每周周六 0 点的时间戳 月: 每月最后一天 0 点的时间戳
+不填就是本周/月的
+
+**接口地址 :** `/listen/data/song/play/rank`
+
+**调用例子 :** `/listen/data/song/play/rank?type=month`
+
 ### 听歌足迹 - 总收听时长
 
 说明 : 登录后调用此接口, 获取总收听时长; 相关接口可能需要 vip 权限


### PR DESCRIPTION
## 新增接口

`listen_data_song_play_rank` — 听歌足迹 · 歌曲播放排行

**接口地址**: `/listen/data/song/play/rank`

获取某周/某月的听歌排行，返回每首歌的播放次数（`playCount`）。与已有的 `listen_data_today_song`（今日收听）同族，补全了「带播放次数的历史周/月榜单」——现有 `listen_data_report` 的 topSongBlock 仅前几名带次数，此接口可拿到完整 Top 榜每首的次数。

### 参数

| 参数 | 必选 | 说明 |
|------|------|------|
| `type` | 是 | 维度类型，`week`（周）/ `month`（月） |
| `endTime` | 否 | 周：每周周六 0 点时间戳；月：每月最后一天 0 点时间戳。不填为本周/本月 |

### 返回

`data.songItems[]`，每项含 `songId / songName / artists / albumName / picUrl / playCount`。默认返回前 20 名（Top20），当周/月实际听歌不足 20 首时返回全部。

### 调用例子

```
/listen/data/song/play/rank?type=month
/listen/data/song/play/rank?type=month&endTime=1748620800000
```

### 改动

- `module/listen_data_song_play_rank.js`：接口实现
- `interface.d.ts`：TypeScript 类型声明
- `public/docs/home.md`：接口文档

### 说明

已本地实测：登录态下返回 200，`songItems` 带真实 `playCount`；与 `listen_data_report` 月报的 topSongBlock 前几名次数交叉核对一致。已通过 `eslint` 检查。
