### PR TITLE
feat(artist): 添加关注歌手新歌播放全部&新作品接口

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -1474,6 +1474,10 @@ export function artist_new_song(
   } & RequestBaseConfig,
 ): Promise<Response>
 
+export function artist_new_song_playall(
+  params: RequestBaseConfig,
+): Promise<Response>
+
 export function artist_detail(
   params: {
     id: number | string

--- a/interface.d.ts
+++ b/interface.d.ts
@@ -1478,6 +1478,16 @@ export function artist_new_song_playall(
   params: RequestBaseConfig,
 ): Promise<Response>
 
+export function artist_new_song_mv_list_v2(
+  params: {
+    startTimestamp?: number | string
+    before?: number | string
+    sourceType?: number | string
+    limit?: number | string
+    firstRequest?: boolean | string
+  } & RequestBaseConfig,
+): Promise<Response>
+
 export function artist_detail(
   params: {
     id: number | string

--- a/module/artist_new_song_mv_list_v2.js
+++ b/module/artist_new_song_mv_list_v2.js
@@ -1,0 +1,16 @@
+// 获取关注歌手的新歌曲和 MV
+
+const createOption = require('../util/option.js')
+module.exports = (query, request) => {
+  const data = {
+    startTimestamp: query.startTimestamp || query.before || Date.now(),
+    sourceType: query.sourceType || 1,
+    limit: query.limit || 10,
+    firstRequest: query.firstRequest ?? true,
+  }
+  return request(
+    `/api/sub/artist/new/works/song-mv/list/v2`,
+    data,
+    createOption(query, 'eapi'),
+  )
+}

--- a/module/artist_new_song_playall.js
+++ b/module/artist_new_song_playall.js
@@ -1,0 +1,10 @@
+// 获取所有关注歌手最近的 50 首新歌
+
+const createOption = require('../util/option.js')
+module.exports = (query, request) => {
+  return request(
+    `/api/sub/artist/new/works/song/playall`,
+    {},
+    createOption(query, 'eapi'),
+  )
+}

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -3620,6 +3620,24 @@ type='1009' 获取其 id, 如`/search?keywords= 代码时间 &type=1009`
 
 **调用例子 :** `/artist/new/song/playall`
 
+### 关注歌手新作品（歌曲/MV）
+
+说明 : 登录后调用此接口可分页获取关注歌手的新歌曲和 MV
+
+**可选参数 :** `limit`: 返回数量，默认为 10
+
+`startTimestamp`: 时间游标，首次请求默认为当前时间，后续请求传入上一页返回的时间游标
+
+`before`: `startTimestamp` 的别名
+
+`sourceType`: 作品来源类型，默认为 1
+
+`firstRequest`: 是否首次请求，默认为 `true`，翻页时传 `false`
+
+**接口地址 :** `/artist/new/song/mv/list/v2`
+
+**调用例子 :** `/artist/new/song/mv/list/v2` `/artist/new/song/mv/list/v2?startTimestamp=1783680576099&sourceType=1&limit=10&firstRequest=false`
+
 ### 关注歌手新 MV
 
 说明 :登录后调用此接口可获取关注歌手新 MV

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -3630,7 +3630,7 @@ type='1009' 获取其 id, 如`/search?keywords= 代码时间 &type=1009`
 
 `before`: `startTimestamp` 的别名
 
-`sourceType`: 作品来源类型，默认为 1
+`sourceType`: 作品来源类型，已确认 `1` 表示新歌，其他取值待确认，默认为 `1`
 
 `firstRequest`: 是否首次请求，默认为 `true`，翻页时传 `false`
 

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -3612,6 +3612,14 @@ type='1009' 获取其 id, 如`/search?keywords= 代码时间 &type=1009`
 
 **调用例子 :** `/artist/new/song?limit=1` `/artist/new/song?limit=1&before=1602777625000`
 
+### 关注歌手最近新歌 - 播放全部
+
+说明 : 登录后调用此接口可获取所有关注歌手最近的 50 首新歌
+
+**接口地址 :** `/artist/new/song/playall`
+
+**调用例子 :** `/artist/new/song/playall`
+
 ### 关注歌手新 MV
 
 说明 :登录后调用此接口可获取关注歌手新 MV


### PR DESCRIPTION
- 新增 module/artist_new_song_playall.js 文件实现获取所有关注歌手最近50首新歌的功能
- 在文档中添加关注歌手最近新歌播放全部接口说明和调用示例
- 在类型定义文件中添加 artist_new_song_playall 函数声明