### PR TITLE
feat(voice): 支持上传声音封面

### DIFF
--- a/interface.d.ts
+++ b/interface.d.ts
@@ -2802,6 +2802,22 @@ export function voice_upload(
       name: string
       data: string | Buffer
     }
+    imgFile?: {
+      name: string
+      data: string | Buffer
+    }
+    voiceListId: string | number
+    coverImgId?: string | number
+    categoryId: string | number
+    secondCategoryId: string | number
+    description: string
+    songName?: string
+    privacy?: string | number
+    publishTime?: string | number
+    autoPublish?: string | number
+    autoPublishText?: string
+    orderNo?: string | number
+    composedSongs?: string
   } & RequestBaseConfig,
 ): Promise<Response>
 

--- a/module/voice_upload.js
+++ b/module/voice_upload.js
@@ -2,6 +2,7 @@ const { default: axios } = require('axios')
 const fs = require('fs')
 var xml2js = require('xml2js')
 
+const uploadPlugin = require('../plugins/upload')
 const createOption = require('../util/option.js')
 const { getFileExtension, readFileChunk } = require('../util/fileHelper')
 
@@ -19,15 +20,7 @@ function createDupkey() {
   return s.join('')
 }
 
-module.exports = async (query, request) => {
-  const ext = getFileExtension(query.songFile.name)
-  const filename =
-    query.songName ||
-    query.songFile.name
-      .replace('.' + ext, '')
-      .replace(/\s/g, '')
-      .replace(/\./g, '_')
-
+module.exports = async (query, request, dependencies = {}) => {
   if (!query.songFile) {
     return Promise.reject({
       status: 500,
@@ -37,6 +30,19 @@ module.exports = async (query, request) => {
       },
     })
   }
+
+  const axiosRequest = dependencies.axios || axios
+  const uploadImage = dependencies.uploadPlugin || uploadPlugin
+  const ext = getFileExtension(query.songFile.name)
+  const filename =
+    query.songName ||
+    query.songFile.name
+      .replace('.' + ext, '')
+      .replace(/\s/g, '')
+      .replace(/\./g, '_')
+  const coverImgId = query.imgFile
+    ? (await uploadImage(query, request)).imgId
+    : query.coverImgId
 
   const tokenRes = await request(
     `/api/nos/token/alloc`,
@@ -53,7 +59,7 @@ module.exports = async (query, request) => {
 
   const objectKey = tokenRes.body.result.objectKey.replace(/\//g, '%2F')
   const docId = tokenRes.body.result.docId
-  const res = await axios({
+  const res = await axiosRequest({
     method: 'post',
     url: `https://ymusic.nos-hz.163yun.com/${objectKey}?uploads`,
     headers: {
@@ -94,7 +100,7 @@ module.exports = async (query, request) => {
       )
     }
 
-    const res3 = await axios({
+    const res3 = await axiosRequest({
       method: 'put',
       url: `https://ymusic.nos-hz.163yun.com/${objectKey}?partNumber=${blockIndex}&uploadId=${res2.InitiateMultipartUploadResult.UploadId[0]}`,
       headers: {
@@ -117,7 +123,7 @@ module.exports = async (query, request) => {
   }
   completeStr += '</CompleteMultipartUpload>'
 
-  await axios({
+  await axiosRequest({
     method: 'post',
     url: `https://ymusic.nos-hz.163yun.com/${objectKey}?uploadId=${res2.InitiateMultipartUploadResult.UploadId[0]}`,
     headers: {
@@ -128,29 +134,29 @@ module.exports = async (query, request) => {
     data: completeStr,
   })
 
+  const voiceData = JSON.stringify([
+    {
+      name: filename,
+      autoPublish: query.autoPublish == 1 ? true : false,
+      autoPublishText: query.autoPublishText || '',
+      description: query.description,
+      voiceListId: query.voiceListId,
+      coverImgId,
+      dfsId: docId,
+      categoryId: query.categoryId,
+      secondCategoryId: query.secondCategoryId,
+      composedSongs: query.composedSongs ? query.composedSongs.split(',') : [],
+      privacy: query.privacy == 1 ? true : false,
+      publishTime: query.publishTime || 0,
+      orderNo: query.orderNo || 1,
+    },
+  ])
+
   await request(
     `/api/voice/workbench/voice/batch/upload/preCheck`,
     {
       dupkey: createDupkey(),
-      voiceData: JSON.stringify([
-        {
-          name: filename,
-          autoPublish: query.autoPublish == 1 ? true : false,
-          autoPublishText: query.autoPublishText || '',
-          description: query.description,
-          voiceListId: query.voiceListId,
-          coverImgId: query.coverImgId,
-          dfsId: docId,
-          categoryId: query.categoryId,
-          secondCategoryId: query.secondCategoryId,
-          composedSongs: query.composedSongs
-            ? query.composedSongs.split(',')
-            : [],
-          privacy: query.privacy == 1 ? true : false,
-          publishTime: query.publishTime || 0,
-          orderNo: query.orderNo || 1,
-        },
-      ]),
+      voiceData,
     },
     {
       ...createOption(query),
@@ -163,25 +169,7 @@ module.exports = async (query, request) => {
     `/api/voice/workbench/voice/batch/upload/v2`,
     {
       dupkey: createDupkey(),
-      voiceData: JSON.stringify([
-        {
-          name: filename,
-          autoPublish: query.autoPublish == 1 ? true : false,
-          autoPublishText: query.autoPublishText || '',
-          description: query.description,
-          voiceListId: query.voiceListId,
-          coverImgId: query.coverImgId,
-          dfsId: docId,
-          categoryId: query.categoryId,
-          secondCategoryId: query.secondCategoryId,
-          composedSongs: query.composedSongs
-            ? query.composedSongs.split(',')
-            : [],
-          privacy: query.privacy == 1 ? true : false,
-          publishTime: query.publishTime || 0,
-          orderNo: query.orderNo || 1,
-        },
-      ]),
+      voiceData,
     },
     {
       ...createOption(query),

--- a/public/docs/home.md
+++ b/public/docs/home.md
@@ -4371,27 +4371,33 @@ ONLINE 已发布
 
 ### 播客上传声音
 
-说明: 可以上传声音到播客,例子在 `/public/voice_upload.html` 访问地址: <a href="/voice_upload.html" target="_blank">/voice_upload.html</a>
+说明: 登录后调用此接口,使用`'Content-Type': 'multipart/form-data'`上传声音文件 formData(name 为`songFile`),可通过 formData(name 为`imgFile`)同时上传声音封面。例子在 `/public/voice_upload.html` 访问地址: <a href="/voice_upload.html" target="_blank">/voice_upload.html</a>
 
 **接口地址:** `/voice/upload`
 
 **必选参数：**
-`voiceListId`: 播客 id
 
-`coverImgId`: 播客封面
+`songFile`: 声音文件
+
+`voiceListId`: 播客 id
 
 `categoryId`: 分类 id
 
-`secondCategoryId`:次级分类 id
+`secondCategoryId`: 次级分类 id
 
 `description`: 声音介绍
 
 **可选参数：**
+
+`imgFile`: 声音封面图片文件,上传后会自动生成图片 id。与`coverImgId`同时传入时,优先使用`imgFile`
+
+`coverImgId`: 已上传的声音封面图片 id,未传入`imgFile`时使用该值
+
 `songName`: 声音名称
 
-`privacy`: 设为隐私声音,播客如果是隐私博客,则必须设为 1
+`privacy`: 设为隐私声音,播客如果是隐私播客,则必须设为 1
 
-`publishTime`:默认立即发布,定时发布的话需传入时间戳
+`publishTime`: 默认立即发布,定时发布的话需传入时间戳
 
 `autoPublish`: 是否发布动态,是则传入 1
 

--- a/public/voice_upload.html
+++ b/public/voice_upload.html
@@ -217,8 +217,13 @@
           </div>
 
           <div class="form-group">
-            <label>选择文件</label>
-            <input type="file" name="songFile" accept="audio/*" />
+            <label for="songFile">选择声音文件</label>
+            <input id="songFile" type="file" name="songFile" accept="audio/*" />
+          </div>
+
+          <div class="form-group">
+            <label for="imgFile">选择声音封面（可选）</label>
+            <input id="imgFile" type="file" name="imgFile" accept="image/*" />
           </div>
 
           <button class="btn" @click="submit">上传</button>
@@ -251,12 +256,13 @@
         methods: {
           submit() {
             console.info('submit')
-            const file = document.querySelector('input[type=file]').files[0]
-            if (!file) {
-              alert('请选择文件')
+            const songFile = document.querySelector('input[name=songFile]').files[0]
+            const imgFile = document.querySelector('input[name=imgFile]').files[0]
+            if (!songFile) {
+              alert('请选择声音文件')
               return
             }
-            this.upload(file)
+            this.upload(songFile, imgFile)
           },
 
           async getData() {
@@ -286,14 +292,17 @@
             }
           },
 
-          upload(file) {
+          upload(songFile, imgFile) {
             if (!this.currentVoice) {
               alert('请先选择播客列表')
               return
             }
 
             var formData = new FormData()
-            formData.append('songFile', file)
+            formData.append('songFile', songFile)
+            if (imgFile) {
+              formData.append('imgFile', imgFile)
+            }
 
             axios({
               method: 'post',
@@ -312,7 +321,7 @@
               data: formData,
             })
               .then((res) => {
-                alert(`${file.name} 上传成功`)
+                alert(`${songFile.name} 上传成功`)
               })
               .catch((err) => {
                 console.error('上传失败:', err)

--- a/public/voice_upload.html
+++ b/public/voice_upload.html
@@ -269,17 +269,23 @@
             this.loading = true
             try {
               const res = await axios({
-                url: `/voicelist/search?cookie=${localStorage.getItem('cookie')}`,
+                url: `/voicelist/my/created?limit=100&cookie=${localStorage.getItem(
+                  'cookie',
+                )}`,
               })
 
               console.info(res.data.data)
-              this.voicelist = res.data.data.list || []
+              this.voicelist = res.data.data.data || []
               this.voicelist.forEach(async (i) => {
                 try {
                   const res2 = await axios({
-                    url: `/voicelist/list?voiceListId=${i.voiceListId}&limit=5`,
+                    url: `/voicelist/list?voiceListId=${
+                      i.voiceListId
+                    }&limit=5&cookie=${localStorage.getItem('cookie')}`,
                   })
-                  i.voiceListData = res2.data.data.list || []
+                  i.voiceListData = res2.data.data
+                    ? res2.data.data.list || []
+                    : []
                   console.info(res2)
                 } catch (err) {
                   console.error('获取播客详情失败:', err)

--- a/test/voice_upload.test.js
+++ b/test/voice_upload.test.js
@@ -1,0 +1,129 @@
+const assert = require('assert')
+const voiceUpload = require('../module/voice_upload')
+
+function createVoiceUploadHarness(uploadPlugin) {
+  const requestCalls = []
+
+  return {
+    requestCalls,
+    dependencies: {
+      uploadPlugin,
+      axios: async (options) => {
+        if (options.method === 'post' && options.url.endsWith('?uploads')) {
+          return {
+            data: '<InitiateMultipartUploadResult><UploadId>upload-id</UploadId></InitiateMultipartUploadResult>',
+          }
+        }
+
+        if (options.method === 'put') {
+          return { headers: { etag: 'etag-1' } }
+        }
+
+        return { data: {} }
+      },
+    },
+    request: async (uri, data, options) => {
+      requestCalls.push({ uri, data, options })
+
+      if (uri === '/api/nos/token/alloc') {
+        return {
+          body: {
+            result: {
+              objectKey: 'voice/audio.mp3',
+              docId: 'audio-doc-id',
+              token: 'nos-token',
+            },
+          },
+        }
+      }
+
+      if (uri === '/api/voice/workbench/voice/batch/upload/v2') {
+        return { body: { data: { voiceId: 'voice-id' } } }
+      }
+
+      return { body: { code: 200 } }
+    },
+  }
+}
+
+function createVoiceUploadQuery(overrides = {}) {
+  const data = Buffer.from('audio')
+
+  return {
+    songFile: {
+      name: 'episode.mp3',
+      mimetype: 'audio/mpeg',
+      size: data.length,
+      data,
+    },
+    voiceListId: 'voice-list-id',
+    categoryId: 'category-id',
+    secondCategoryId: 'second-category-id',
+    description: 'episode description',
+    ...overrides,
+  }
+}
+
+describe('voice upload cover', () => {
+  it('uses the uploaded image as the cover for every voice submission', async () => {
+    let uploadedQuery
+    const harness = createVoiceUploadHarness(async (query) => {
+      uploadedQuery = query
+      return { imgId: 'uploaded-cover-id' }
+    })
+    const query = createVoiceUploadQuery({
+      imgFile: {
+        name: 'cover.jpg',
+        mimetype: 'image/jpeg',
+        data: Buffer.from('image'),
+      },
+      coverImgId: 'fallback-cover-id',
+    })
+
+    const result = await voiceUpload(
+      query,
+      harness.request,
+      harness.dependencies,
+    )
+    const voiceCalls = harness.requestCalls.filter((call) =>
+      call.uri.startsWith('/api/voice/workbench/voice/batch/upload'),
+    )
+
+    assert.strictEqual(uploadedQuery, query)
+    assert.strictEqual(voiceCalls.length, 2)
+    voiceCalls.forEach((call) => {
+      const [voiceData] = JSON.parse(call.data.voiceData)
+      assert.strictEqual(voiceData.coverImgId, 'uploaded-cover-id')
+    })
+    assert.deepStrictEqual(result, {
+      status: 200,
+      body: {
+        code: 200,
+        data: { voiceId: 'voice-id' },
+      },
+    })
+  })
+
+  it('keeps using coverImgId when no image file is uploaded', async () => {
+    let uploaded = false
+    const harness = createVoiceUploadHarness(async () => {
+      uploaded = true
+      return { imgId: 'unexpected-cover-id' }
+    })
+
+    await voiceUpload(
+      createVoiceUploadQuery({ coverImgId: 'existing-cover-id' }),
+      harness.request,
+      harness.dependencies,
+    )
+
+    const voiceCalls = harness.requestCalls.filter((call) =>
+      call.uri.startsWith('/api/voice/workbench/voice/batch/upload'),
+    )
+    assert.strictEqual(uploaded, false)
+    voiceCalls.forEach((call) => {
+      const [voiceData] = JSON.parse(call.data.voiceData)
+      assert.strictEqual(voiceData.coverImgId, 'existing-cover-id')
+    })
+  })
+})


### PR DESCRIPTION
## 改动说明

- 为 `/voice/upload` 新增可选的 multipart `imgFile` 字段，复用现有图片上传流程，并将生成的图片 ID 同时用于预检和正式提交。
- 保留原有 `coverImgId` 用法；同时传入时优先使用 `imgFile`，避免破坏现有调用方。
- 更新上传示例页、接口文档和 TypeScript 类型声明，说明文件字段及参数优先级。
- 修正示例页的播客列表加载逻辑，改为读取当前账号创建的播客，并在详情请求中携带登录态。
- 增加测试，覆盖新图片上传路径与原有 `coverImgId` 兼容路径。

## 验证

- `corepack pnpm@9.15.9 lint`
- `corepack pnpm@9.15.9 docs:check`
- `corepack pnpm@9.15.9 exec tsc --noEmit`
- `corepack pnpm@9.15.9 test`（15 passing）
- 本地真实账号端到端上传：声音最终状态为 `ONLINE`
- 返回封面尺寸为 `1011 × 1012`，与本地测试图一致
- 抽样 16,129 个像素，平均每通道差异为 `0.9115`，符合服务端 JPEG 重编码特征，确认自定义封面真实生效
- 测试声音已删除，并复查测试播客声音列表为空

## 兼容性

- 未传 `imgFile` 时继续使用原有 `coverImgId`
- 同时传入 `imgFile` 和 `coverImgId` 时，以 `imgFile` 上传后生成的图片 ID 为准

Closes #211